### PR TITLE
[IM] API & UI for filtering Integrations by category

### DIFF
--- a/x-pack/legacy/plugins/integrations_manager/common/routes.ts
+++ b/x-pack/legacy/plugins/integrations_manager/common/routes.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { PLUGIN } from './constants';
-import { AssetType } from './types';
+import { AssetType, CategoryId } from './types';
 
 export const API_ROOT = `/api/${PLUGIN.ID}`;
 export const API_LIST_PATTERN = `${API_ROOT}/list`;
@@ -12,6 +12,10 @@ export const API_INFO_PATTERN = `${API_ROOT}/package/{pkgkey}`;
 export const API_INSTALL_PATTERN = `${API_ROOT}/install/{pkgkey}/{asset?}`;
 export const API_DELETE_PATTERN = `${API_ROOT}/delete/{pkgkey}/{asset?}`;
 export const API_CATEGORIES_PATTERN = `${API_ROOT}/categories`;
+
+export interface ListParams {
+  category?: CategoryId;
+}
 
 export function getCategoriesPath() {
   return API_CATEGORIES_PATTERN;

--- a/x-pack/legacy/plugins/integrations_manager/common/routes.ts
+++ b/x-pack/legacy/plugins/integrations_manager/common/routes.ts
@@ -11,6 +11,11 @@ export const API_LIST_PATTERN = `${API_ROOT}/list`;
 export const API_INFO_PATTERN = `${API_ROOT}/package/{pkgkey}`;
 export const API_INSTALL_PATTERN = `${API_ROOT}/install/{pkgkey}/{asset?}`;
 export const API_DELETE_PATTERN = `${API_ROOT}/delete/{pkgkey}/{asset?}`;
+export const API_CATEGORIES_PATTERN = `${API_ROOT}/categories`;
+
+export function getCategoriesPath() {
+  return API_CATEGORIES_PATTERN;
+}
 
 export function getListPath() {
   return API_LIST_PATTERN;

--- a/x-pack/legacy/plugins/integrations_manager/common/types.ts
+++ b/x-pack/legacy/plugins/integrations_manager/common/types.ts
@@ -44,8 +44,9 @@ export interface ServiceRequirements {
 // from /categories
 // https://github.com/elastic/integrations-registry/blob/master/docs/api/categories.json
 export type CategorySummaryList = CategorySummaryItem[];
+export type CategoryId = string;
 export interface CategorySummaryItem {
-  id: string;
+  id: CategoryId;
   title: string;
   count: number;
 }

--- a/x-pack/legacy/plugins/integrations_manager/common/types.ts
+++ b/x-pack/legacy/plugins/integrations_manager/common/types.ts
@@ -41,6 +41,15 @@ export interface ServiceRequirements {
   'version.max': RequirementVersion;
 }
 
+// from /categories
+// https://github.com/elastic/integrations-registry/blob/master/docs/api/categories.json
+export type CategorySummaryList = CategorySummaryItem[];
+export interface CategorySummaryItem {
+  id: string;
+  title: string;
+  count: number;
+}
+
 export type RequirementsByServiceName = Record<ServiceName, ServiceRequirements>;
 export interface AssetParts {
   pkgkey: string;

--- a/x-pack/legacy/plugins/integrations_manager/public/components/integration_list_grid.tsx
+++ b/x-pack/legacy/plugins/integrations_manager/public/components/integration_list_grid.tsx
@@ -18,7 +18,7 @@ export function IntegrationListGrid({ title, list }: ListProps) {
 
   return (
     <Fragment>
-      <EuiSpacer />
+      <EuiSpacer size="xl" />
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>
           <EuiText>
@@ -33,7 +33,7 @@ export function IntegrationListGrid({ title, list }: ListProps) {
           </EuiFlexGrid>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer />
+      <EuiSpacer size="xl" />
     </Fragment>
   );
 }

--- a/x-pack/legacy/plugins/integrations_manager/public/components/integration_list_grid.tsx
+++ b/x-pack/legacy/plugins/integrations_manager/public/components/integration_list_grid.tsx
@@ -3,35 +3,29 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactNode } from 'react';
 import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import { IntegrationList, IntegrationListItem } from '../../common/types';
 import { IntegrationCard } from './integration_card';
 
 interface ListProps {
+  controls: ReactNode;
   title: string;
   list: IntegrationList;
 }
 
-export function IntegrationListGrid({ title, list }: ListProps) {
+export function IntegrationListGrid({ controls, title, list }: ListProps) {
   if (!list.length) return null;
+
+  const controlsContent = <ControlsColumn title={title} controls={controls} />;
+  const gridContent = <GridColumn list={list} />;
 
   return (
     <Fragment>
       <EuiSpacer size="xl" />
       <EuiFlexGroup>
-        <EuiFlexItem grow={1}>
-          <EuiText>
-            <h2>{title}</h2>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={3}>
-          <EuiFlexGrid gutterSize="l" columns={3}>
-            {list.map(item => (
-              <GridItem key={`${item.name}-${item.version}`} {...item} />
-            ))}
-          </EuiFlexGrid>
-        </EuiFlexItem>
+        <EuiFlexItem grow={1}>{controlsContent}</EuiFlexItem>
+        <EuiFlexItem grow={3}>{gridContent}</EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xl" />
     </Fragment>
@@ -43,5 +37,30 @@ function GridItem(item: IntegrationListItem) {
     <EuiFlexItem>
       <IntegrationCard {...item} />
     </EuiFlexItem>
+  );
+}
+
+function ControlsColumn({ controls, title }: { controls: ReactNode; title: string }) {
+  return (
+    <Fragment>
+      <EuiText>
+        <h2>{title}</h2>
+      </EuiText>
+      <EuiSpacer size="xl" />
+      <EuiFlexGroup>
+        <EuiFlexItem grow={2}>{controls}</EuiFlexItem>
+        <EuiFlexItem grow={1} />
+      </EuiFlexGroup>
+    </Fragment>
+  );
+}
+
+function GridColumn({ list }: { list: IntegrationList }) {
+  return (
+    <EuiFlexGrid gutterSize="l" columns={3}>
+      {list.map(item => (
+        <GridItem key={`${item.name}-${item.version}`} {...item} />
+      ))}
+    </EuiFlexGrid>
   );
 }

--- a/x-pack/legacy/plugins/integrations_manager/public/data.ts
+++ b/x-pack/legacy/plugins/integrations_manager/public/data.ts
@@ -5,13 +5,31 @@
  */
 
 import { HttpHandler } from 'src/core/public';
-import { getInstallPath, getInfoPath, getListPath, getRemovePath } from '../common/routes';
-import { IntegrationInfo, IntegrationList, IntegrationsGroupedByStatus } from '../common/types';
+import {
+  getCategoriesPath,
+  getInfoPath,
+  getInstallPath,
+  getListPath,
+  getRemovePath,
+} from '../common/routes';
+import {
+  CategorySummaryList,
+  IntegrationInfo,
+  IntegrationList,
+  IntegrationsGroupedByStatus,
+} from '../common/types';
 
 let _fetch: HttpHandler;
 
 export function setClient(client: HttpHandler): void {
   _fetch = client;
+}
+
+export async function getCategories(): Promise<CategorySummaryList> {
+  const path = getCategoriesPath();
+  const list: CategorySummaryList = await _fetch(path);
+
+  return list;
 }
 
 export async function getIntegrations(): Promise<IntegrationList> {

--- a/x-pack/legacy/plugins/integrations_manager/public/data.ts
+++ b/x-pack/legacy/plugins/integrations_manager/public/data.ts
@@ -11,6 +11,7 @@ import {
   getInstallPath,
   getListPath,
   getRemovePath,
+  ListParams,
 } from '../common/routes';
 import {
   CategorySummaryList,
@@ -32,9 +33,10 @@ export async function getCategories(): Promise<CategorySummaryList> {
   return list;
 }
 
-export async function getIntegrations(): Promise<IntegrationList> {
+export async function getIntegrations(params?: ListParams): Promise<IntegrationList> {
   const path = getListPath();
-  const list: IntegrationList = await _fetch(path);
+  const options = params ? { query: { ...params } } : undefined;
+  const list: IntegrationList = await _fetch(path, options);
 
   return list;
 }

--- a/x-pack/legacy/plugins/integrations_manager/public/screens/home.tsx
+++ b/x-pack/legacy/plugins/integrations_manager/public/screens/home.tsx
@@ -7,11 +7,13 @@ import React, { Fragment, useState, useEffect } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   // @ts-ignore (elastic/eui#1557) & (elastic/eui#1262) EuiImage is not exported yet
   EuiImage,
   EuiPage,
   EuiPageBody,
   EuiPageWidthProps,
+  EuiSpacer,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -42,10 +44,8 @@ function HomeLayout(props: LayoutProps) {
   const { list, restrictWidth } = props;
   if (!list) return null;
 
-  const { theme } = useCore();
-  const FullWidthHeader = styled(EuiPage)`
-    border-bottom: ${theme.eui.euiBorderThin};
-    padding-bottom: ${theme.eui.paddingSizes.s};
+  const FullBleedPage = styled(EuiPage)`
+    padding: 0;
   `;
 
   const availableTitle = 'Available Integrations';
@@ -54,26 +54,29 @@ function HomeLayout(props: LayoutProps) {
 
   return (
     <Fragment>
-      <FullWidthHeader>
+      <FullBleedPage>
         <EuiPageBody restrictWidth={restrictWidth}>
           <Header />
         </EuiPageBody>
-      </FullWidthHeader>
-      <EuiPage>
+      </FullBleedPage>
+      <EuiHorizontalRule margin="none" />
+      <FullBleedPage>
         <EuiPageBody restrictWidth={restrictWidth}>
           <Fragment>
+            <EuiSpacer size="l" />
             <IntegrationListGrid title={installedTitle} list={installedIntegrations} />
+            <EuiHorizontalRule margin="l" />
             <IntegrationListGrid title={availableTitle} list={list} />
           </Fragment>
         </EuiPageBody>
-      </EuiPage>
+      </FullBleedPage>
     </Fragment>
   );
 }
 
 function Header() {
   return (
-    <EuiFlexGroup>
+    <EuiFlexGroup gutterSize="none">
       <EuiFlexItem grow={1}>
         <HeroCopy />
       </EuiFlexItem>
@@ -91,7 +94,7 @@ function HeroCopy() {
   `;
 
   return (
-    <EuiFlexGroup alignItems="center">
+    <EuiFlexGroup alignItems="center" gutterSize="none">
       <EuiFlexItem>
         <EuiTitle size="l">
           <h1>Add Your Data</h1>
@@ -104,13 +107,16 @@ function HeroCopy() {
 
 function HeroImage() {
   const { toAssets } = useLinks();
+  const FlexGroup = styled(EuiFlexGroup)`
+    margin-bottom: -6px; // puts image directly on EuiHorizontalRule
+  `;
 
   return (
-    <EuiFlexGroup justifyContent="flexEnd">
+    <FlexGroup gutterSize="none" justifyContent="flexEnd">
       <EuiImage
         alt="Illustration of computer"
         url={toAssets('illustration_kibana_getting_started@2x.png')}
       />
-    </EuiFlexGroup>
+    </FlexGroup>
   );
 }

--- a/x-pack/legacy/plugins/integrations_manager/server/integrations/get.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/integrations/get.ts
@@ -14,6 +14,10 @@ function nameAsTitle(name: string) {
   return name.charAt(0).toUpperCase() + name.substr(1).toLowerCase();
 }
 
+export async function getCategories() {
+  return Registry.fetchCategories();
+}
+
 export async function getIntegrations(options: { savedObjectsClient: SavedObjectsClientContract }) {
   const { savedObjectsClient } = options;
   const registryItems = await Registry.fetchList().then(items =>

--- a/x-pack/legacy/plugins/integrations_manager/server/integrations/get.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/integrations/get.ts
@@ -18,9 +18,11 @@ export async function getCategories() {
   return Registry.fetchCategories();
 }
 
-export async function getIntegrations(options: { savedObjectsClient: SavedObjectsClientContract }) {
+export async function getIntegrations(
+  options: { savedObjectsClient: SavedObjectsClientContract } & Registry.SearchParams
+) {
   const { savedObjectsClient } = options;
-  const registryItems = await Registry.fetchList().then(items =>
+  const registryItems = await Registry.fetchList({ category: options.category }).then(items =>
     items.map(item => Object.assign({}, item, { title: item.title || nameAsTitle(item.name) }))
   );
   const searchObjects = registryItems.map(({ name, version }) => ({

--- a/x-pack/legacy/plugins/integrations_manager/server/integrations/handlers.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/integrations/handlers.ts
@@ -44,7 +44,10 @@ export async function handleGetCategories(req: Request, extra: Extra) {
 
 export async function handleGetList(req: Request, extra: Extra) {
   const savedObjectsClient = getClient(req);
-  const integrationList = await getIntegrations({ savedObjectsClient });
+  const integrationList = await getIntegrations({
+    savedObjectsClient,
+    category: req.query.category,
+  });
 
   return integrationList;
 }

--- a/x-pack/legacy/plugins/integrations_manager/server/integrations/handlers.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/integrations/handlers.ts
@@ -8,6 +8,7 @@ import { AssetType, Request, ResponseToolkit } from '../../common/types';
 import { PluginContext } from '../plugin';
 import { getClient } from '../saved_objects';
 import {
+  getCategories,
   getClusterAccessor,
   getIntegrationInfo,
   getIntegrations,
@@ -36,6 +37,10 @@ interface DeleteAssetRequest extends Request {
 type AssetRequestParams = PackageRequest['params'] & {
   asset?: AssetType;
 };
+
+export async function handleGetCategories(req: Request, extra: Extra) {
+  return getCategories();
+}
 
 export async function handleGetList(req: Request, extra: Extra) {
   const savedObjectsClient = getClient(req);

--- a/x-pack/legacy/plugins/integrations_manager/server/registry/index.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/registry/index.ts
@@ -7,6 +7,7 @@
 import {
   AssetsGroupedByServiceByType,
   AssetParts,
+  CategorySummaryList,
   RegistryList,
   RegistryPackage,
 } from '../../common/types';
@@ -25,6 +26,10 @@ export async function fetchList(): Promise<RegistryList> {
 
 export async function fetchInfo(key: string): Promise<RegistryPackage> {
   return fetchUrl(`${REGISTRY}/package/${key}`).then(JSON.parse);
+}
+
+export async function fetchCategories(): Promise<CategorySummaryList> {
+  return fetchUrl(`${REGISTRY}/categories`).then(JSON.parse);
 }
 
 export async function getArchiveInfo(

--- a/x-pack/legacy/plugins/integrations_manager/server/registry/index.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/registry/index.ts
@@ -4,9 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { URL } from 'url';
 import {
   AssetsGroupedByServiceByType,
   AssetParts,
+  CategoryId,
   CategorySummaryList,
   RegistryList,
   RegistryPackage,
@@ -19,9 +21,17 @@ import { streamToBuffer } from './streams';
 export { ArchiveEntry } from './extract';
 
 const REGISTRY = process.env.REGISTRY || 'http://integrations-registry.app.elstc.co';
+export interface SearchParams {
+  category?: CategoryId;
+}
 
-export async function fetchList(): Promise<RegistryList> {
-  return fetchUrl(`${REGISTRY}/search`).then(JSON.parse);
+export async function fetchList(params?: SearchParams): Promise<RegistryList> {
+  const url = new URL(`${REGISTRY}/search`);
+  if (params && params.category) {
+    url.searchParams.set('category', params.category);
+  }
+
+  return fetchUrl(url.toString()).then(JSON.parse);
 }
 
 export async function fetchInfo(key: string): Promise<RegistryPackage> {

--- a/x-pack/legacy/plugins/integrations_manager/server/routes.ts
+++ b/x-pack/legacy/plugins/integrations_manager/server/routes.ts
@@ -12,6 +12,12 @@ import * as Integrations from './integrations/handlers';
 export const routes: ServerRoute[] = [
   {
     method: 'GET',
+    path: CommonRoutes.API_CATEGORIES_PATTERN,
+    options: { tags: [`access:${PLUGIN.ID}`], json: { space: 2 } },
+    handler: Integrations.handleGetCategories,
+  },
+  {
+    method: 'GET',
     path: CommonRoutes.API_LIST_PATTERN,
     options: { tags: [`access:${PLUGIN.ID}`], json: { space: 2 } },
     handler: Integrations.handleGetList,


### PR DESCRIPTION
## API & UI for filtering Integrations by category
> Filters for "All" (not filtered) & each category. Only one active filter at a time.

closes #46070

![45562-category-filters](https://user-images.githubusercontent.com/57655/65177195-3dadf800-da24-11e9-9f7a-9258f647b0aa.gif)

I'll add some comments inline but see the individual commits for more context.

Did separate UI & API commits and tried to keep related changes together to make it easier to follow.